### PR TITLE
From "draft" to "develop" 

### DIFF
--- a/DotNetTransformer/DotNetTransformer_vs2008.csproj
+++ b/DotNetTransformer/DotNetTransformer_vs2008.csproj
@@ -24,7 +24,7 @@
 		<Reference Include="System.Drawing" />
 	</ItemGroup>
 	<ItemGroup>
-		<Compile Include="**\*.cs" Exclude="Test\**\*.cs" />
+		<Compile Include="**\*.cs" Exclude="Test\**" />
 	</ItemGroup>
 	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/DotNetTransformer/DotNetTransformer_vs2010.csproj
+++ b/DotNetTransformer/DotNetTransformer_vs2010.csproj
@@ -24,7 +24,7 @@
 		<Reference Include="System.Drawing" />
 	</ItemGroup>
 	<ItemGroup>
-		<Compile Include="**\*.cs" Exclude="Test\**\*.cs" />
+		<Compile Include="**\*.cs" Exclude="Test\**" />
 	</ItemGroup>
 	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/DotNetTransformer/DotNetTransformer_vs2013.csproj
+++ b/DotNetTransformer/DotNetTransformer_vs2013.csproj
@@ -24,7 +24,7 @@
 		<Reference Include="System.Drawing" />
 	</ItemGroup>
 	<ItemGroup>
-		<Compile Include="**\*.cs" Exclude="Test\**\*.cs" />
+		<Compile Include="**\*.cs" Exclude="Test\**" />
 	</ItemGroup>
 	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/DotNetTransformer/Extensions/EnumerableExtension.cs
+++ b/DotNetTransformer/Extensions/EnumerableExtension.cs
@@ -7,8 +7,8 @@
 //	Author   : leofun01
 
 using System.Collections.Generic;
-using FlipRotate2d = DotNetTransformer.Math.Group.FlipRotate2d;
 using RotateFlipType = System.Drawing.RotateFlipType;
+using FlipRotate2d = DotNetTransformer.Math.Group.FlipRotate2d;
 
 namespace DotNetTransformer.Extensions {
 	public static class EnumerableExtension

--- a/DotNetTransformer/Extensions/RotateFlipTypeExtension.cs
+++ b/DotNetTransformer/Extensions/RotateFlipTypeExtension.cs
@@ -198,9 +198,8 @@ namespace DotNetTransformer.Extensions {
 			//return Compose(Compose(_this, _this), _this);
 		}
 		public static int GetCycleLength(this RotateFlipType _this) {
-			byte t = (byte)_this;
-			return 0x22224241 >> (t << 2) & 7;
-			//return 1 << (0x5598 >> (t << 1) & 3);
+			return 0x22224241 >> ((byte)_this << 2) & 7;
+			//return 1 << (0x5598 >> ((byte)_this << 1) & 3);
 		}
 		public static RotateFlipType Add(this RotateFlipType _this, RotateFlipType other) {
 			byte t = (byte)_this, o = (byte)other;

--- a/DotNetTransformer/Extensions/RotateFlipTypeExtension.cs
+++ b/DotNetTransformer/Extensions/RotateFlipTypeExtension.cs
@@ -200,6 +200,8 @@ namespace DotNetTransformer.Extensions {
 		public static int GetCycleLength(this RotateFlipType _this) {
 			return 0x22224241 >> ((byte)_this << 2) & 7;
 			//return 1 << (0x5598 >> ((byte)_this << 1) & 3);
+			//byte t = (byte)_this;
+			//return 1 << (20 >> t & 3 | (t >> 2));
 		}
 		public static RotateFlipType Add(this RotateFlipType _this, RotateFlipType other) {
 			byte t = (byte)_this, o = (byte)other;


### PR DESCRIPTION
- Update DotNetTransformer_vs20XX.csproj (exclude all test files)
- Update EnumerableExtension.cs (unify usings order)
- Update RotateFlipTypeExtension.cs (GetCycleLength is complete)